### PR TITLE
refactor: standardize grading output pattern - replace INDIVIDUAL.md

### DIFF
--- a/docs/ai/CONVENTIONS.md
+++ b/docs/ai/CONVENTIONS.md
@@ -31,6 +31,8 @@ Follow these without question. Do not deviate unless explicitly told.
 - All grading content must use second-person address (Sie or Du based on class); never use third-person to refer to the student.
 - In `repograde`, derive output filenames from the repository basename; single-repo and bulk per-repo outputs are `<basename>_grading.md` and `<basename>_email.json`.
 - `repograde` must never write `INDIVIDUAL.md` or `CLASS.md`.
+- `knowledge-assessment` must write per-student `<name>_grading.md` files instead of `INDIVIDUAL.md`.
+- `knowledge-assessment` must always write `GRADINGS.md` and `CLASS.md` (both mandatory).
 - Shared `EMAIL.json` is created only by the bulk-mode master workflow after all per-repo outputs are finished.
 - In bulk repository grading, use dynamic concurrency with default 4 concurrent runs and an approximately 3-second delay before starting the next run.
 - All grading reports written in German with 0-100 score (Endbewertung)

--- a/docs/ai/DECISIONS.md
+++ b/docs/ai/DECISIONS.md
@@ -76,3 +76,11 @@ Each entry documents WHAT was decided and WHY.
 - **Reason**: Third-person address ("der Schüler hat...") is inconsistent with email salutations and feels impersonal; students should be addressed directly
 - **Considered**: Mixed third-person in reports with second-person in emails, or only second-person in emails
 - **Tradeoff**: Requires careful grammar (Sie vs Du conjugation), but creates consistent student experience
+
+## 2026-03-23: Replace INDIVIDUAL.md with per-student grading files
+- **Choice**: All grading skills use `<name>_grading.md` pattern instead of a single `INDIVIDUAL.md` file
+- **Reason**: Consistent output pattern across all grading skills (repograde, knowledge-assessment, projectgrade); per-student files are easier to manage and align with `<basename>_grading.md` convention
+- **Considered**: Keeping `INDIVIDUAL.md` for knowledge-assessment only, or using a different naming scheme
+- **Tradeoff**: More files to manage in knowledge-assessment, but consistency across all grading workflows
+- **Affected skills**: `knowledge-assessment` (now outputs `<name>_grading.md` instead of `INDIVIDUAL.md`)
+- **Retained outputs**: `GRADINGS.md` and `CLASS.md` remain mandatory for knowledge-assessment

--- a/docs/ai/HANDOFF.md
+++ b/docs/ai/HANDOFF.md
@@ -1,7 +1,8 @@
 # Handoff
 
-No pending tasks. Last cleared: 2026-03-21.
+No pending tasks. Last cleared: 2026-03-23.
 
 ## Branch:
 
+fix/issue-26 → PR #27 (merged or ready for review)
 main

--- a/docs/ai/PITFALLS.md
+++ b/docs/ai/PITFALLS.md
@@ -26,7 +26,15 @@ Read this file carefully before making changes in affected areas.
 ## Grading Workflow
 
 - Never assume grading commands run from within a Git repository - they operate from a local folder (CWD)
+- `projectgrade` is the exception: it MUST run from within a Git repository (the project being evaluated)
 - `Hausübungen.md` is always in the CWD, never inside a student repository
 - `Hausübungen.md` may be a symbolic link; follow symlinks when reading
 - Student repositories must already exist locally; never attempt to clone them
 - If any student repository has uncommitted changes, grading must stop immediately
+- All grading skills use `<name>_grading.md` pattern; `INDIVIDUAL.md` is deprecated
+- `knowledge-assessment` outputs `GRADINGS.md` and `CLASS.md` (both mandatory) plus per-student `<name>_grading.md` files
+
+## Project Configuration
+
+- OpenClaw-specific configuration (agent binding, Telegram groups, memory settings) belongs in OpenClaw's channel config, not in `AGENTS.md` or other project files
+- Project `AGENTS.md` should contain only project-relevant instructions and conventions

--- a/docs/ai/STATE.md
+++ b/docs/ai/STATE.md
@@ -1,28 +1,24 @@
-# Current State (2026-03-21)
+# Current State (2026-03-23)
 
 Project status snapshot. This file is overwritten on every save.
 
 ## Current Focus
 
-Education-focused commands and skills for German class workflows, with repository grading consolidated into `repograde`.
+Standardizing grading output across all assessment skills to use `<name>_grading.md` pattern.
 
 ## Completed (this cycle)
 
-- [x] Fixed execution context terminology: local folder vs Git repository distinction
-- [x] Added Execution Context section to `repograde` skill with explicit no-cloning rule
-- [x] Added Pre-Grading Verification with `git pull` and `git status` checks
-- [x] Added constraint: uncommitted changes = stop immediately
-- [x] Fixed `Hausübungen.md` location clarification (CWD, not inside repo)
-- [x] Added Execution Context section to `knowledge-assessment` skill
-- [x] Clarified `vacuum.db` must exist at start, error if missing
-- [x] Updated `repograde` and `knowledge-assess` commands with execution context warnings
-- [x] Updated `grading-shared` skill with vacuum.db pre-existence requirement
+- [x] Removed `INDIVIDUAL.md` from `knowledge-assessment` outputs
+- [x] Added per-student `<name>_grading.md` files to `knowledge-assessment`
+- [x] Updated `grading-shared` to reference `*_grading.md` pattern
+- [x] Updated `CONVENTIONS.md` with knowledge-assessment output rules
+- [x] Added decision record in `DECISIONS.md`
+- [x] Created PR #27 for projectgrade skill with Git repository execution context
 
 ## Pending
 
-- [ ] Test revised grading workflow with real student repositories
-- [ ] Consider adding utility scripts
-- [ ] Validate skill loading from the linked `.config/OpenCode/Skills` environment
+- [ ] Test revised grading workflows with real data
+- [ ] Validate that all grading skills produce consistent output patterns
 
 ## Blockers
 
@@ -30,4 +26,4 @@ None
 
 ## Next Session Suggestion
 
-Test the revised `repograde` workflow with a real student repository to verify execution context rules and second-person address work correctly.
+Test the `knowledge-assessment` workflow with actual student submissions to verify the new `<name>_grading.md` output pattern works correctly.

--- a/skills/grading-shared/SKILL.md
+++ b/skills/grading-shared/SKILL.md
@@ -89,8 +89,7 @@ When gender is not clear from first name:
 
 ALL grading content must address the student directly in the second person,
 matching the email salutation style. This applies to:
-- `_grading.md` files (repograde)
-- `INDIVIDUAL.md` files (knowledge-assessment)
+- `*_grading.md` files (repograde, knowledge-assessment, projectgrade)
 - Email body text in `EMAIL.json`
 
 ### Pronoun and Verb conjugation
@@ -203,6 +202,7 @@ Table: `users`
 ## Output Expectations
 
 This skill provides configuration only. Consuming skills produce:
-- Individual assessment files (all in second-person German)
-- EMAIL.json with personalized payloads (second-person body)
-- Class-wide reports (anonymized, no student address needed)
+- Per-student `*_grading.md` files with individual feedback (second-person German)
+- `EMAIL.json` with personalized payloads (second-person body)
+- `GRADINGS.md` class-wide overview (where applicable)
+- `CLASS.md` anonymized class patterns (where applicable)

--- a/skills/knowledge-assessment/SKILL.md
+++ b/skills/knowledge-assessment/SKILL.md
@@ -88,10 +88,10 @@ alongside knowledge-check solution files.
 - Create `GRADINGS.md` in German.
 - Include a comprehensive table ordered alphabetically by student name, not by
   grade.
-- Create `INDIVIDUAL.md` in German.
+- Create `<name>_grading.md` for each student in German (e.g., `haas_alexander_grading.md`).
 - Address each student directly in the second person (Sie or Du based on class).
 - Provide a relatively detailed assessment for each student's submission.
-- Ensure every reported score in `INDIVIDUAL.md` is consistent with the
+- Ensure every reported score in the grading file is consistent with the
   authoritative total achievable points from the solutions file.
 - Use a respectful teacher-to-student tone that is friendly, warm, and
   encouraging without becoming inappropriately informal.
@@ -105,54 +105,51 @@ alongside knowledge-check solution files.
   for the teacher on how to address them.
 - Do not name any students in `CLASS.md` because it is intended for a public
   repository.
+- Do NOT create `INDIVIDUAL.md` (deprecated; use per-student `<name>_grading.md` files).
 
-### Example: Second-Person Tone in INDIVIDUAL.md (Informal/2ahwii)
+### Example: Second-Person Tone in `<name>_grading.md` (Informal/2ahwii)
 
 ```
-# Individuelle Bewertung
-
-## Haas Alexander (2AHWII)
+# Bewertung: Haas Alexander (2AHWII)
 
 Du hast bei dieser Wissensüberprüfung insgesamt 72 von 80 Punkten erreicht.
 Das ist eine solide Leistung.
 
-### Stärken
+## Stärken
 
 Du hast Frage 3 (SQL-JOINs) vollständig und korrekt beantwortet. Auch bei
 Frage 7 (Normalisierung) hast du die Grundkonzepte gut verstanden.
 
-### Verbesserungspotenzial
+## Verbesserungspotenzial
 
 Bei Frage 4 (Subqueries) wäre etwas mehr Erklärung hilfreich gewesen. Du hast
 die Antwort zwar angegeben, aber den Lösungsweg nicht erläutert.
 
-### Empfehlungen
+## Empfehlungen
 
 Es empfiehlt sich, die Unterschiede zwischen INNER JOIN und OUTER JOIN noch
 einmal zu üben. Nutze dazu die hochgeladene Lösungedatei als Referenz.
 ```
 
-### Example: Second-Person Tone in INDIVIDUAL.md (Formal/Other class)
+### Example: Second-Person Tone in `<name>_grading.md` (Formal/Other class)
 
 ```
-# Individuelle Bewertung
-
-## Huber Maria (5AHIF)
+# Bewertung: Huber Maria (5AHIF)
 
 Sie haben bei dieser Wissensüberprüfung insgesamt 68 von 80 Punkten erreicht.
 Das ist eine gute Leistung.
 
-### Stärken
+## Stärken
 
 Sie haben Frage 3 (SQL-JOINs) vollständig und korrekt beantwortet. Auch bei
 Frage 7 (Normalisierung) haben Sie die Grundkonzepte gut verstanden.
 
-### Verbesserungspotenzial
+## Verbesserungspotenzial
 
 Bei Frage 4 (Subqueries) wäre etwas mehr Erklärung hilfreich gewesen. Sie haben
 die Antwort zwar angegeben, aber den Lösungsweg nicht erläutert.
 
-### Empfehlungen
+## Empfehlungen
 
 Es empfiehlt sich, die Unterschiede zwischen INNER JOIN und OUTER JOIN noch
 einmal zu üben. Nutzen Sie dazu die hochgeladene Lösungedatei als Referenz.
@@ -172,7 +169,7 @@ Additional requirements specific to knowledge-check:
 - Each object must contain exactly these fields (see `grading-shared` for structure):
   - `mailto`: recipient email address
   - `subject`: `Ergebnis der Wissensüberprüfung am <isodate>`
-  - `body`: the student's individual assessment text
+  - `body`: the student's individual assessment text (from `<name>_grading.md`)
 - Ensure every reported score inside the email body is consistent with the
   authoritative total achievable points from the solutions file.
 - Use greeting and closing formulas from `grading-shared` based on class
@@ -181,7 +178,7 @@ Additional requirements specific to knowledge-check:
   mit den korrekten Lösungen in das Git-Repository hochgeladen.` Place this
   note near the end of the body, before the closing formula.
 - If gender cannot be determined, use neutral fallback greeting per
-  `grading-shared` protocol and flag in `INDIVIDUAL.md` for manual review.
+  `grading-shared` protocol and flag in the grading file for manual review.
 
 ### 5. Constraints
 
@@ -189,9 +186,10 @@ Additional requirements specific to knowledge-check:
 - Write all report files in German.
 - Write `EMAIL.json` bodies in German.
 - All student-facing content must use second-person address (Sie or Du).
-- Never use third-person references to the student in INDIVIDUAL.md or emails.
-- Treat `INDIVIDUAL.md` as the source for the personalized email bodies.
-- Keep `CLASS.md` anonymous.
+- Never use third-person references to the student in grading files or emails.
+- Use per-student `<name>_grading.md` files as the source for personalized email bodies.
+- Keep `GRADINGS.md` as a class-wide overview table.
+- Keep `CLASS.md` anonymous for public repository use.
 - UTF-8 is explicitly allowed and preferred in both Markdown and JSON outputs.
 - Write German umlauts and Eszett in natural UTF-8 form in generated `.md`
   and `.json` files, for example `ä`, `ö`, `ü`, `Ä`, `Ö`, `Ü`, and `ß`.
@@ -203,12 +201,12 @@ Additional requirements specific to knowledge-check:
 - Follow email constraints from `grading-shared` (greeting, closing, trailing
   comma, paragraph spacing).
 - If any point-total consistency error appears between the solutions file,
-  `INDIVIDUAL.md`, or `EMAIL.json`, stop immediately instead of generating or
+  grading files, or `EMAIL.json`, stop immediately instead of generating or
   continuing with inconsistent output.
 
 ## Output Expectations
 
-- `GRADINGS.md` with class-wide grading overview.
-- `INDIVIDUAL.md` with detailed per-student feedback.
-- `CLASS.md` with anonymized class patterns and teacher recommendations.
-- `EMAIL.json` with one personalized email payload per student.
+- `GRADINGS.md` with class-wide grading overview (mandatory)
+- `CLASS.md` with anonymized class patterns and teacher recommendations (mandatory)
+- `<name>_grading.md` files (one per student) with detailed individual feedback
+- `EMAIL.json` with one personalized email payload per student


### PR DESCRIPTION
## Summary

Standardizes grading output across all assessment skills to use a consistent `<name>_grading.md` pattern instead of `INDIVIDUAL.md`.

Follow-up to #26.

## Changes

- **knowledge-assessment**: Now outputs per-student `<name>_grading.md` files instead of single `INDIVIDUAL.md`
- **grading-shared**: Updated references from `INDIVIDUAL.md` to `*_grading.md` pattern
- **CONVENTIONS.md**: Added knowledge-assessment output conventions
- **DECISIONS.md**: Added decision record for this change
- **PITFALLS.md**: Added notes about projectgrade execution context and grading output patterns

## Required Outputs

| Skill | Outputs |
|-------|---------|
| `repograde` | `<basename>_grading.md`, `<basename>_email.json` |
| `projectgrade` | `<basename>_grading.md`, `<basename>_email.json` |
| `knowledge-assessment` | `GRADINGS.md`, `CLASS.md`, `<name>_grading.md`×N, `EMAIL.json` |

## Commits

- `refactor: replace INDIVIDUAL.md with <name>_grading.md pattern`
- `docs: persist knowledge from session - grading output standardization`