### PR TITLE
Add automatic assessment disclaimer to all grading templates

### DIFF
--- a/docs/ai/CONVENTIONS.md
+++ b/docs/ai/CONVENTIONS.md
@@ -23,7 +23,7 @@ Follow these without question. Do not deviate unless explicitly told.
 - `repograde` is the canonical repository-grading skill; it handles both full-history and date-filtered grading. There is no separate command — invoke the skill directly.
 - `repograde` repository grading reports must use one exact top-level section order: `Rahmen`, `Commit-Überblick`, `Pünktlichkeit der Abgaben`, `Hausübungs-Abdeckung`, `Codequalität`, `Konkrete technische Beobachtungen`, `Stärken`, `Verbesserungspotenzial`, `Endbewertung`.
 - `repograde` subagents must not improvise free-form grading bodies; they must keep the required section order, include the required metrics, and stay within the requested section scope.
-- `repograde` homework grading emails must follow one fixed paragraph order: greeting, grading period opening, commit summary, homework overview, per-homework evaluation, coverage/timeliness summary, recommendations, final score, closing.
+- `repograde` homework grading emails must follow one fixed paragraph order: greeting, automatic assessment disclaimer, grading period opening, commit summary, homework overview, per-homework evaluation, coverage/timeliness summary, recommendations, final score, closing.
 - `projectgrade` is the project-grading skill; it runs from inside the project Git repo. There is no separate command — invoke the skill directly.
 - Grading operates from a local folder (CWD), NOT from within a Git repository — except `projectgrade` which MUST run from inside a Git repo.
 - `Hausübungen.md` (legacy, cumulative) or per-lesson `Hausübung.md` files in `<date>_<topic>` directories provide homework assignments for grading; at least one must exist in the CWD.

--- a/docs/ai/DECISIONS.md
+++ b/docs/ai/DECISIONS.md
@@ -175,3 +175,9 @@ Each entry documents WHAT was decided and WHY.
 - **Considered**: Adding the rule to AGENTS.md (always enforced), extending the issue-workflow skill, creating a policy directory
 - **Tradeoff**: The policy only applies when explicitly loaded, but this avoids imposing restrictions on non-fork projects
 - **Fork detection**: A repository is treated as a fork if it has more than one remote (simple heuristic)
+
+## 2026-05-21: Add automatic assessment disclaimer to all grading emails
+- **Choice**: Insert an automatic assessment disclaimer paragraph directly below the email greeting in all grading workflows.
+- **Reason**: Transparency for students that the assessment is generated automatically and may contain errors.
+- **Wording**: Tailored to address style (Du vs Sie) and type of assessment (Leistungsfeststellung vs Knowledge-Check).
+- **Tradeoff**: Adds minor boilerplate, but establishes proper expectations and handles potential auto-assessment mistakes gracefully.

--- a/docs/ai/STATE.md
+++ b/docs/ai/STATE.md
@@ -1,14 +1,18 @@
 # Project State
 
-Current status as of 2026-04-24.
+Current status as of 2026-05-21.
 
 ## Current Focus
 
-Created fork-policy skill for clean-main enforcement on forked repositories.
+Added automatic assessment disclaimers to all student-facing grading email templates.
 
 ## Completed (this cycle)
 
 - [x] Created `skills/fork-policy/SKILL.md` with clean-main policy, branch naming convention, fork detection, safety checks, and issue-workflow integration guidance
+- [x] Updated `skills/grading-shared/SKILL.md` to add `### Automatic Assessment Disclaimers` section (Formal/Informal, Leistungsfeststellung/Knowledge-Check)
+- [x] Updated paragraph sequence templates for Homework and Knowledge-Check Emails in `grading-shared`
+- [x] Updated templates and email paragraph sequence lists in `skills/repograde/SKILL.md`, `skills/knowledge-assessment/SKILL.md`, and `docs/ai/CONVENTIONS.md`
+- [x] Documented the update in `docs/ai/DECISIONS.md`
 
 ## Pending
 
@@ -20,4 +24,4 @@ None
 
 ## Next Session Suggestion
 
-Consider adding a thin command wrapper (`/fork-check`) that loads the fork-policy skill for quick branch safety verification.
+Verify template compliance across actual grading run output examples with real student submissions.

--- a/skills/grading-shared/SKILL.md
+++ b/skills/grading-shared/SKILL.md
@@ -128,6 +128,22 @@ Lieben Gruß,
    Georg Graf
 ```
 
+### Automatic Assessment Disclaimers
+
+Every grading email body MUST include a disclaimer paragraph directly below the greeting. The wording depends on the class's address style (Formal/Informal) and the assessment type (Homework/Projects vs. Knowledge-Checks):
+
+**Formal Address (Sie):**
+- **Homework / Projects / General (Leistungsfeststellung):**
+  `Im Folgenden finden Sie die automatische Beurteilung Ihrer Leistungsfeststellung. Bitte beachten Sie, dass diese Beurteilung Irrtümer enthalten kann.`
+- **Knowledge-Checks / Mini-Exams (Knowledge-Check):**
+  `Im Folgenden finden Sie die automatische Beurteilung Ihres Knowledge-Checks. Bitte beachten Sie, dass diese Beurteilung Irrtümer enthalten kann.`
+
+**Informal Address (Du):**
+- **Homework / Projects / General (Leistungsfeststellung):**
+  `Im Folgenden findest du die automatische Beurteilung deiner Leistungsfeststellung. Bitte beachte, dass diese Beurteilung Irrtümer enthalten kann.`
+- **Knowledge-Checks / Mini-Exams (Knowledge-Check):**
+  `Im Folgenden findest du die automatische Beurteilung deines Knowledge-Checks. Bitte beachte, dass diese Beurteilung Irrtümer enthalten kann.`
+
 ### Gender Determination
 
 Gender is determined from the **first name** (the last word in the repository
@@ -539,7 +555,9 @@ this exact paragraph order:
 
 1. **Greeting** — per Greeting Formulas section above.
 
-2. **Opening sentence** (address style dependent):
+2. **Automatic assessment disclaimer** — per Automatic Assessment Disclaimers section above.
+
+3. **Opening sentence** (address style dependent):
    - Formal: `Ich habe Ihre Hausübungen, welche im Zeitraum vom [Start-Datum] bis zum [End-Datum] aufgegeben waren, durchgesehen.`
    - Informal: `Ich habe deine Hausübungen, welche im Zeitraum vom [Start-Datum] bis zum [End-Datum] aufgegeben waren, durchgesehen.`
    - Dates in German long format (e.g., "18. Februar 2026", "4. März 2026").
@@ -589,11 +607,13 @@ Used by `knowledge-assessment` skill. Same plain-text rule applies.
 
 1. **Greeting** — per Greeting Formulas section above.
 
-2. **Opening sentence** (address style dependent):
+2. **Automatic assessment disclaimer** — per Automatic Assessment Disclaimers section above.
+
+3. **Opening sentence** (address style dependent):
    - Formal: `Ich habe Ihre Wissensüberprüfung vom [Datum] durchgesehen.`
    - Informal: `Ich habe deine Wissensüberprüfung vom [Datum] durchgesehen.`
 
-3. **Score summary** — Total points achieved out of total possible points.
+4. **Score summary** — Total points achieved out of total possible points.
 
 4. **Question-by-question analysis** — Plain text paragraphs discussing
    strengths and weaknesses in specific questions.
@@ -628,6 +648,8 @@ something well, state it matter-of-factly.
 
 ```
 Sehr geehrte Frau Huber,
+
+im Folgenden finden Sie die automatische Beurteilung Ihrer Leistungsfeststellung. Bitte beachten Sie, dass diese Beurteilung Irrtümer enthalten kann.
 
 Ich habe Ihre Hausübungen, welche im Zeitraum vom 4. März bis zum
 18. März aufgegeben waren, durchgesehen.
@@ -690,6 +712,8 @@ Mit freundlichen Grüßen,
 
 ```
 Lieber Thomas,
+
+im Folgenden findest du die automatische Beurteilung deiner Leistungsfeststellung. Bitte beachte, dass diese Beurteilung Irrtümer enthalten kann.
 
 Ich habe deine Hausübungen, welche im Zeitraum vom 4. März bis zum
 18. März aufgegeben waren, durchgesehen.

--- a/skills/knowledge-assessment/SKILL.md
+++ b/skills/knowledge-assessment/SKILL.md
@@ -179,7 +179,8 @@ Additional requirements specific to knowledge-check:
   - `subject`: `Ergebnis der Wissensüberprüfung am <isodate>`
   - `body`: the student's individual assessment text, formatted as plain ASCII
     text following the `grading-shared` Email Body Format section for
-    knowledge-check emails.
+    knowledge-check emails. Place the automatic assessment disclaimer paragraph
+    immediately after the greeting.
 - Ensure every reported score inside the email body is consistent with the
   authoritative total achievable points from the solutions file.
 - Use greeting and closing formulas from `grading-shared` based on class

--- a/skills/repograde/SKILL.md
+++ b/skills/repograde/SKILL.md
@@ -520,14 +520,15 @@ Additionally, every repograde email body MUST summarize the following in the
 same fixed structure for every student:
 
 1. greeting,
-2. grading period opening,
-3. commit activity summary,
-4. homework overview,
-5. per-homework evaluation paragraphs,
-6. homework coverage and timeliness summary,
-7. recommendations,
-8. final weighted score,
-9. closing.
+2. automatic assessment disclaimer paragraph,
+3. grading period opening,
+4. commit activity summary,
+5. homework overview,
+6. per-homework evaluation paragraphs,
+7. homework coverage and timeliness summary,
+8. recommendations,
+9. final weighted score,
+10. closing.
 
 Within that fixed order, ensure that the combined homework evaluation and
 coverage paragraphs clearly communicate code quality, missing work, lateness,


### PR DESCRIPTION
## Summary
- Added configuration for formal and informal automatic assessment disclaimers to `grading-shared`
- Updated paragraph sequence and example email templates for Homework and Knowledge-Check Emails
- Documented changes in conventions, decisions, and state files
- Resolves #49